### PR TITLE
Fix/dasboard visualizations fetching

### DIFF
--- a/client/src/components/AddVisualizationToDashboardModal/AddVisualizationToDashboardModal.js
+++ b/client/src/components/AddVisualizationToDashboardModal/AddVisualizationToDashboardModal.js
@@ -21,7 +21,8 @@ const AddVisualizationToDashboardModal = ({ closeModal, addVisualization, isVisi
   }, [visualizations]);
 
   const addNewVisualization = (id, tableId) => () => {
-    dbTableAPIService.getTableData(tableId, { settings: [] }).then((data) => {
+    const { config, datasetSettings } = visualizations.find((vis) => vis.id === id);
+    dbTableAPIService.getTableData(tableId, { settings: datasetSettings, config }).then((data) => {
       addVisualization(id, data);
       closeModal();
     });

--- a/client/src/components/BarChart/BarChart.js
+++ b/client/src/components/BarChart/BarChart.js
@@ -157,7 +157,7 @@ function BarChart(props) {
           .text(goal.label);
       }
     }
-
+    console.log(YAxis);
     YAxis.key.forEach((YKey,index) => drawLine(YKey, index));
 
     if (trendline.display && data.length && YAxis.key.length === 1) {

--- a/client/src/components/BarChart/BarChart.js
+++ b/client/src/components/BarChart/BarChart.js
@@ -157,7 +157,6 @@ function BarChart(props) {
           .text(goal.label);
       }
     }
-    console.log(YAxis);
     YAxis.key.forEach((YKey,index) => drawLine(YKey, index));
 
     if (trendline.display && data.length && YAxis.key.length === 1) {

--- a/client/src/components/FilterBar/FilterFieldsList.js
+++ b/client/src/components/FilterBar/FilterFieldsList.js
@@ -56,6 +56,7 @@ function FilterFieldsList({ schema, chooseFilterHandler, activeFilterName }) {
 
         return disabled ? (
           <Tooltip
+            key={index + Date.now()}
             classes={{
               tooltip: classes.unknownTypeTooltip,
             }}

--- a/client/src/components/FilterBar/styles.js
+++ b/client/src/components/FilterBar/styles.js
@@ -45,9 +45,7 @@ const useStyles = makeStyles(() => ({
     '&:hover': {
       color: '#2e363b',
     },
-    // fontSize: '20px',
     cursor: 'pointer',
-    // marginLeft: '20px',
   },
 }));
 

--- a/client/src/components/InitialTable/InitialTable.js
+++ b/client/src/components/InitialTable/InitialTable.js
@@ -42,7 +42,7 @@ const InitialTable = (props) => {
   const tableProperties = getTableHead(data);
   useEffect(() => {
     setData(formatDateForSummarize(Data, config));
-  }, [Data]);
+  }, [Data, config]);
   const tableHeadRows = tableProperties.map((property) => (
     <TableCell
       key={property}

--- a/client/src/components/InitialTable/InitialTable.js
+++ b/client/src/components/InitialTable/InitialTable.js
@@ -33,6 +33,7 @@ const sortByProperty = (arrOfObjects, property, sortedBy) => {
   }
   return arrOfObjects;
 };
+
 const InitialTable = (props) => {
   const { data: Data, config } = props;
   const [data, setData] = useState(formatDateForSummarize(Data, config));
@@ -80,6 +81,7 @@ const InitialTable = (props) => {
 InitialTable.propTypes = {
   data: PropTypes.array,
   config: PropTypes.object,
+  schema: PropTypes.array,
 };
 
 export default InitialTable;

--- a/client/src/components/SelectVisualizationSidebar/SelectVisualizationSidebar.js
+++ b/client/src/components/SelectVisualizationSidebar/SelectVisualizationSidebar.js
@@ -5,13 +5,18 @@ import TimelineOutlinedIcon from '@material-ui/icons/TimelineOutlined';
 import MapOutlinedIcon from '@material-ui/icons/MapOutlined';
 import AppsIcon from '@material-ui/icons/Apps';
 import { useHistory } from 'react-router-dom';
+import { Tooltip } from '@material-ui/core';
+
 import PropTypes from 'prop-types';
 
 import useStyles from './styles';
+import { canTableBeDisplayed } from '../../containers/ViewVisualizationContainer/helpers/initVisualizationHelper';
 
-const SelectVisualizationSidebar = ({ tableId }) => {
+const SelectVisualizationSidebar = ({ tableId, schema }) => {
   const history = useHistory();
   const classes = useStyles();
+
+  const chartVisualizations = ['line-chart', 'bar-chart'];
 
   const myVisualizations = [
     {
@@ -50,11 +55,34 @@ const SelectVisualizationSidebar = ({ tableId }) => {
   return (
     <div className={classes.basicContainer}>
       {myVisualizations.map((item, index) => {
-        return (
-          <Button key={index} onClick={() => onButtonClick(item.type)} className={classes.buttonStyle} id={item.id}>
+        const disabled = canTableBeDisplayed(schema) && chartVisualizations.includes(item.type);
+
+        const visButton = (
+          <Button
+            disabled={disabled}
+            key={index}
+            onClick={() => onButtonClick(item.type)}
+            className={classes.buttonStyle}
+            id={item.id}
+          >
             {item.icon}
             <span className={classes.visName}>{item.name}</span>
           </Button>
+        );
+
+        return disabled ? (
+          <Tooltip
+            key={index + Date.now()}
+            style={{ display: 'inline' }}
+            classes={{
+              tooltip: classes.invalidDataTooltip,
+            }}
+            title={`This table has no valid data to display ${item.type}`}
+          >
+            <div>{visButton}</div>
+          </Tooltip>
+        ) : (
+          visButton
         );
       })}
     </div>
@@ -63,6 +91,7 @@ const SelectVisualizationSidebar = ({ tableId }) => {
 
 SelectVisualizationSidebar.propTypes = {
   tableId: PropTypes.string,
+  schema: PropTypes.array,
 };
 
 export default SelectVisualizationSidebar;

--- a/client/src/components/SelectVisualizationSidebar/styles.js
+++ b/client/src/components/SelectVisualizationSidebar/styles.js
@@ -31,6 +31,9 @@ const useStyles = makeStyles((theme) => ({
     bottom: '-30px',
     color: '#33A1DE',
   },
+  invalidDataTooltip: {
+    fontSize: '13px',
+  },
 }));
 
 export default useStyles;

--- a/client/src/components/ViewVisualizationHeader/ViewVisualizationHeader.js
+++ b/client/src/components/ViewVisualizationHeader/ViewVisualizationHeader.js
@@ -48,6 +48,7 @@ const ViewVisualizationHeader = (props) => {
                 <InfoIcon className={classes.viewVisualizationTitleIcon} />
               </Tooltip>
             )}
+            <EditIcon className={classes.viewVisualizationTitleIcon} onClick={onVisualizationNameEdit} />
             <div>
               {(isVisualizationExist && datasetSettings?.length && (
                 <Chip
@@ -79,7 +80,6 @@ const ViewVisualizationHeader = (props) => {
                 })) ||
                 null}
             </div>
-            <EditIcon className={classes.viewVisualizationTitleIcon} onClick={onVisualizationNameEdit} />
           </>
         )}
       </Grid>

--- a/client/src/containers/InitialTableContainer/InitialTableContainer.js
+++ b/client/src/containers/InitialTableContainer/InitialTableContainer.js
@@ -4,12 +4,13 @@ import { InitialTable } from '../../components/index';
 
 const InitialTableContainer = (props) => {
   const { data, config } = props;
-  return <InitialTable data={data} config={config} />;
+  return data.length ? <InitialTable data={data} config={config} /> : 'There is no data to show';
 };
 
 InitialTableContainer.propTypes = {
   data: PropTypes.array,
   config: PropTypes.object,
+  schema: PropTypes.array,
 };
 
 export default InitialTableContainer;

--- a/client/src/containers/ViewVisualizationContainer/ViewVisualizationContainer.js
+++ b/client/src/containers/ViewVisualizationContainer/ViewVisualizationContainer.js
@@ -112,7 +112,7 @@ const ViewVisualizationContainer = (props) => {
     // eslint-disable-next-line no-nested-ternary
     schema && data ? (
       currentView === 'table' ? (
-        <InitialTable data={data} config={currentVisualization.config} schema={schema} />
+        <InitialTable data={data} config={currentVisualization.config} />
       ) : (
         visualizationComponent
       )
@@ -183,7 +183,7 @@ const ViewVisualizationContainer = (props) => {
     closeModal();
   };
 
-  const selectVisualizationSidebar = getSelectVisualizationSidebar(tableId);
+  const selectVisualizationSidebar = getSelectVisualizationSidebar(tableId, schema);
 
   return !currentVisualization.created || !schema || !data ? (
     <div style={{ position: 'relative' }}>

--- a/client/src/containers/ViewVisualizationContainer/helpers/initConfigsHelper/barChartConfig.js
+++ b/client/src/containers/ViewVisualizationContainer/helpers/initConfigsHelper/barChartConfig.js
@@ -1,6 +1,7 @@
 function createInitBarChartConfig(schema, getYKeys, getXKeys) {
   const YKeys = getYKeys(schema);
   const XKeys = getXKeys(schema);
+
   return {
     axisData: {
       XAxis: {
@@ -11,8 +12,8 @@ function createInitBarChartConfig(schema, getYKeys, getXKeys) {
       },
       YAxis: {
         availableKeys: YKeys,
-        key: [YKeys[1]],
-        label: YKeys[1],
+        key: [YKeys[0]],
+        label: YKeys[0],
         displayLabel: true,
       },
     },

--- a/client/src/containers/ViewVisualizationContainer/helpers/initConfigsHelper/lineChartConfig.js
+++ b/client/src/containers/ViewVisualizationContainer/helpers/initConfigsHelper/lineChartConfig.js
@@ -1,6 +1,7 @@
 function createInitLineChartConfig(schema, getYKeys, getXKeys) {
   const YKeys = getYKeys(schema);
   const XKeys = getXKeys(schema);
+
   return {
     axisData: {
       XAxis: {
@@ -11,8 +12,8 @@ function createInitLineChartConfig(schema, getYKeys, getXKeys) {
       },
       YAxis: {
         availableKeys: YKeys,
-        key: [YKeys[1]],
-        label: YKeys[1],
+        key: [YKeys[0]],
+        label: YKeys[0],
         displayLabel: true,
       },
     },

--- a/client/src/containers/ViewVisualizationContainer/helpers/initVisualizationHelper.js
+++ b/client/src/containers/ViewVisualizationContainer/helpers/initVisualizationHelper.js
@@ -28,6 +28,10 @@ export const getYKeys = (schema) => {
   return availableKeys.map((obj) => obj.column_name);
 };
 
+export const canTableBeDisplayed = (schema) => {
+  return !getYKeys(schema).length;
+};
+
 export const getXKeys = (schema) => {
   const availableKeys = schema.filter(({ data_type }) => {
     const isNum = data_type === 'number';

--- a/client/src/containers/ViewVisualizationContainer/helpers/visualizationDataHelper.js
+++ b/client/src/containers/ViewVisualizationContainer/helpers/visualizationDataHelper.js
@@ -18,17 +18,21 @@ import {
 } from '../../../components';
 
 export const getVisualizationComponent = (visualizationType, config, updateConfig, data) => {
-  switch (visualizationType) {
-    case 'BAR_CHART':
-      return <BarChart config={config} data={data} />;
-    case 'LINE_CHART':
-      return <LineChart config={config} data={data} />;
-    case 'TABLE':
-      return <TableVisualization config={config} updateConfig={updateConfig} data={data} />;
-    case 'MAP':
-      return <MapVisualization config={config} updateConfig={updateConfig} data={data} />;
-    default:
-      return null;
+  if (data?.length) {
+    switch (visualizationType) {
+      case 'BAR_CHART':
+        return <BarChart config={config} data={data} />;
+      case 'LINE_CHART':
+        return <LineChart config={config} data={data} />;
+      case 'TABLE':
+        return <TableVisualization config={config} updateConfig={updateConfig} data={data} />;
+      case 'MAP':
+        return <MapVisualization config={config} updateConfig={updateConfig} data={data} />;
+      default:
+        return null;
+    }
+  } else {
+    return 'There is no data to show';
   }
 };
 
@@ -68,6 +72,6 @@ export const getVisualizationSettings = (visualizationType, config, updateConfig
   }
 };
 
-export const getSelectVisualizationSidebar = (tableId) => {
-  return <SelectVisualizationSidebar tableId={tableId} />;
+export const getSelectVisualizationSidebar = (tableId, schema) => {
+  return <SelectVisualizationSidebar tableId={tableId} schema={schema} />;
 };

--- a/server/src/services/dbTableService.js
+++ b/server/src/services/dbTableService.js
@@ -10,7 +10,7 @@ export const getAllByDatabaseId = async (id) => {
 
 export const getTableData = async (id, { settings, config }) => {
   let data = null;
-  const {isSummarize, summarize} = config ? JSON.parse(config) : {isSummarize: false, summarize: {}};
+  const { isSummarize, summarize } = config ? JSON.parse(config) : { isSummarize: false, summarize: {} };
   const table = await DBTable.getById(id);
   if (table) {
     let manager = new DBManager(table.DatabaseId);
@@ -39,9 +39,6 @@ export const getTableSchema = async (id) => {
       await manager.init();
       schema = await manager.getTableSchemaByName(table.name);
     } catch (error) {
-      // console.log('///////////////////// ON GET TABLE SCHEMA FAILED');
-      // console.log(error);
-      // console.log('///////////////////// ON GET TABLE SCHEMA FAILED');
       schema = null;
       throw createError(400, 'Get table schema failed');
     }


### PR DESCRIPTION
- fixed logic with adding and deleting filters
- disabled buttons for charts which can not be built with that table data
- add tooltips for disabled chart buttons and disabled filter buttons
- if data is empty, show the corresponding message
- fixed visualization fetching on it`s adding to dashboard